### PR TITLE
add_key migration: exclude abstract classes -> FKs without table

### DIFF
--- a/lib/generators/templates/immigration.rb.erb
+++ b/lib/generators/templates/immigration.rb.erb
@@ -1,6 +1,6 @@
 class <%= migration_class_name %> < ActiveRecord::Migration
   def change
-<% @keys.each do |key| -%>
+<% @keys.reject{ |k| k.from_table.nil? || k.to_table.nil? }.each do |key| -%>
     <%= key.to_ruby(:add) %>
 <%- end -%>
   end


### PR DESCRIPTION
If a relationship is defined in an abstract class, the FK is created with `nil` on `from_table` or `to_table`. This provokes a no method error on nil class.

In order to avoid that, we can exclude from the FKs list any FK with a missing table.