### PR TITLE
A rake task that checks for missing keys and exits with an error code.

### DIFF
--- a/lib/immigrant/railtie.rb
+++ b/lib/immigrant/railtie.rb
@@ -6,8 +6,13 @@ module Immigrant
         Immigrant.load
       end
     end
+
     generators do
-      require "generators/immigration_generator"
+      require 'generators/immigration_generator'
+    end
+
+    rake_tasks do
+      require 'immigrant/task'
     end
   end
 end

--- a/lib/immigrant/task.rb
+++ b/lib/immigrant/task.rb
@@ -1,0 +1,20 @@
+namespace :immigrant do
+  desc 'Checks for missing foreign key relationships in the database'
+  task check_keys: :environment do
+    Rails.application.eager_load!
+
+    keys, warnings = Immigrant::KeyFinder.new.infer_keys
+    warnings.values.each { |warning| $stderr.puts "WARNING: #{warning}" }
+
+    keys.each do |key|
+      column = key.options[:column]
+      pk = key.options[:primary_key]
+      $stderr.puts "Missing foreign key relationship on '#{key.from_table}.#{column}' to '#{key.to_table}.#{pk}'"
+    end
+
+    if keys.any?
+      puts 'Found missing foreign keys, run `rails generate immigration MigrationName` to create a migration to add them.'
+      exit keys.count
+    end
+  end
+end


### PR DESCRIPTION
This is in response to https://github.com/jenseng/immigrant/issues/22 and is a rake task that can be used in a CI or otherwise.

The task itself works but the loading of it doesn't. The `defined?(Rake)` is always `nil`. If anyone knows how to straiten that out, I'll make the changes and update the PR.