### PR TITLE
update travis config for newer rubies and rails versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
   - 1.9.3
-  - 2.1.5
-  - 2.3.1
+  - 2.1.10
+  - 2.3.5
+  - 2.5.0
 gemfile:
   - gemfiles/activerecord_3.0.gemfile
   - gemfiles/activerecord_3.1.gemfile
@@ -11,23 +12,43 @@ gemfile:
   - gemfiles/activerecord_4.1.gemfile
   - gemfiles/activerecord_4.2.gemfile
   - gemfiles/activerecord_5.0.gemfile
+  - gemfiles/activerecord_5.1.gemfile
+  - gemfiles/activerecord_5.2.gemfile
   - gemfiles/activerecord_edge.gemfile
 matrix:
   exclude:
-    - rvm: 2.3.1
+    - rvm: 2.5.0
       gemfile: gemfiles/activerecord_3.0.gemfile
-    - rvm: 2.3.1
+    - rvm: 2.5.0
       gemfile: gemfiles/activerecord_3.1.gemfile
-    - rvm: 2.3.1
+    - rvm: 2.5.0
       gemfile: gemfiles/activerecord_3.2.gemfile
-    - rvm: 2.1.5
+    - rvm: 2.5.0
+      gemfile: gemfiles/activerecord_4.0.gemfile
+    - rvm: 2.5.0
+      gemfile: gemfiles/activerecord_4.1.gemfile
+    - rvm: 2.3.5
       gemfile: gemfiles/activerecord_3.0.gemfile
-    - rvm: 2.1.5
+    - rvm: 2.3.5
+      gemfile: gemfiles/activerecord_3.1.gemfile
+    - rvm: 2.3.5
+      gemfile: gemfiles/activerecord_3.2.gemfile
+    - rvm: 2.1.10
+      gemfile: gemfiles/activerecord_3.0.gemfile
+    - rvm: 2.1.10
       gemfile: gemfiles/activerecord_5.0.gemfile
-    - rvm: 2.1.5
+    - rvm: 2.1.10
+      gemfile: gemfiles/activerecord_5.1.gemfile
+    - rvm: 2.1.10
+      gemfile: gemfiles/activerecord_5.2.gemfile
+    - rvm: 2.1.10
       gemfile: gemfiles/activerecord_edge.gemfile
     - rvm: 1.9.3
       gemfile: gemfiles/activerecord_5.0.gemfile
+    - rvm: 1.9.3
+      gemfile: gemfiles/activerecord_5.1.gemfile
+    - rvm: 1.9.3
+      gemfile: gemfiles/activerecord_5.2.gemfile
     - rvm: 1.9.3
       gemfile: gemfiles/activerecord_edge.gemfile
   allow_failures:

--- a/Appraisals
+++ b/Appraisals
@@ -27,6 +27,18 @@ appraise "activerecord-4.2" do
   gem "activerecord", "~> 4.2.0"
 end
 
+appraise "activerecord-5.0" do
+  gem "activerecord", "~> 5.0.0"
+end
+
+appraise "activerecord-5.1" do
+  gem "activerecord", "~> 5.1.0"
+end
+
+appraise "activerecord-5.2" do
+  gem "activerecord", "~> 5.2.x"
+end
+
 appraise "activerecord-edge" do
   gem "arel", github: "rails/arel"
   gem "activerecord", github: "rails/rails"

--- a/gemfiles/activerecord_3.0.gemfile
+++ b/gemfiles/activerecord_3.0.gemfile
@@ -15,4 +15,4 @@ group :test do
   gem "minitest-stub_any_instance"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/activerecord_3.1.gemfile
+++ b/gemfiles/activerecord_3.1.gemfile
@@ -15,4 +15,4 @@ group :test do
   gem "minitest-stub_any_instance"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/activerecord_3.2.gemfile
+++ b/gemfiles/activerecord_3.2.gemfile
@@ -15,4 +15,4 @@ group :test do
   gem "minitest-stub_any_instance"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/activerecord_4.0.gemfile
+++ b/gemfiles/activerecord_4.0.gemfile
@@ -15,4 +15,4 @@ group :test do
   gem "minitest-stub_any_instance"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/activerecord_4.2.gemfile
+++ b/gemfiles/activerecord_4.2.gemfile
@@ -14,4 +14,4 @@ group :test do
   gem "minitest-stub_any_instance"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/activerecord_5.0.gemfile
+++ b/gemfiles/activerecord_5.0.gemfile
@@ -14,4 +14,4 @@ group :test do
   gem "minitest-stub_any_instance"
 end
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/activerecord_5.1.gemfile
+++ b/gemfiles/activerecord_5.1.gemfile
@@ -2,8 +2,7 @@
 
 source "http://rubygems.org"
 
-gem "activerecord", "~> 4.1.0"
-gem "foreigner", "~> 1.2"
+gem "activerecord", "~> 5.1.0"
 
 group :development do
   gem "appraisal"

--- a/gemfiles/activerecord_5.2.gemfile
+++ b/gemfiles/activerecord_5.2.gemfile
@@ -2,8 +2,7 @@
 
 source "http://rubygems.org"
 
-gem "activerecord", "~> 4.1.0"
-gem "foreigner", "~> 1.2"
+gem "activerecord", "~> 5.2.x"
 
 group :development do
   gem "appraisal"

--- a/gemfiles/activerecord_edge.gemfile
+++ b/gemfiles/activerecord_edge.gemfile
@@ -2,8 +2,8 @@
 
 source "http://rubygems.org"
 
-gem "arel", :github => "rails/arel"
-gem "activerecord", :github => "rails/rails"
+gem "arel", github: "rails/arel"
+gem "activerecord", github: "rails/rails"
 
 group :development do
   gem "appraisal"
@@ -15,4 +15,4 @@ group :test do
   gem "minitest-stub_any_instance"
 end
 
-gemspec :path => "../"
+gemspec path: "../"


### PR DESCRIPTION
Updated Appraisals to include newer rails versions, updated travis config to cover more ruby versions.

At what point do we quit testing against unsupported versions of ruby?