### PR TITLE
Add line breaks

### DIFF
--- a/lib/immigrant/task.rb
+++ b/lib/immigrant/task.rb
@@ -6,6 +6,8 @@ namespace :immigrant do
     keys, warnings = Immigrant::KeyFinder.new.infer_keys
     warnings.values.each { |warning| $stderr.puts "WARNING: #{warning}" }
 
+    puts if keys.any?
+
     keys.each do |key|
       column = key.options[:column]
       pk = key.options[:primary_key]
@@ -13,6 +15,7 @@ namespace :immigrant do
     end
 
     if keys.any?
+      puts
       puts 'Found missing foreign keys, run `rails generate immigration MigrationName` to create a migration to add them.'
       exit keys.count
     end

--- a/lib/immigrant/task.rb
+++ b/lib/immigrant/task.rb
@@ -5,10 +5,10 @@ namespace :immigrant do
 
     keys, warnings = Immigrant::KeyFinder.new.infer_keys
 
-    puts if warnings.values.any?
+    $stderr.puts if warnings.values.any?
     warnings.values.each { |warning| $stderr.puts "WARNING: #{warning}" }
 
-    puts if keys.any?
+    $stderr.puts if keys.any?
     keys.each do |key|
       column = key.options[:column]
       pk = key.options[:primary_key]
@@ -16,8 +16,8 @@ namespace :immigrant do
     end
 
     if keys.any?
-      puts
-      puts 'Found missing foreign keys, run `rails generate immigration MigrationName` to create a migration to add them.'
+      $stderr.puts
+      $stderr.puts 'Found missing foreign keys, run `rails generate immigration MigrationName` to create a migration to add them.'
       exit keys.count
     end
   end

--- a/lib/immigrant/task.rb
+++ b/lib/immigrant/task.rb
@@ -4,10 +4,11 @@ namespace :immigrant do
     Rails.application.eager_load!
 
     keys, warnings = Immigrant::KeyFinder.new.infer_keys
+
+    puts if warnings.values.any?
     warnings.values.each { |warning| $stderr.puts "WARNING: #{warning}" }
 
     puts if keys.any?
-
     keys.each do |key|
       column = key.options[:column]
       pk = key.options[:primary_key]


### PR DESCRIPTION
Currently when we run this task in our CI, our output looks like this:

```
/home/circleci/bundler-cache/****/2.7.0/gems/net-protocol-0.2.1/lib/net/protocol.rb:68: warning: already initialized constant Net::ProtocRetryError
/usr/local/lib/****/2.7.0/net/protocol.rb:66: warning: previous definition of ProtocRetryError was here
/home/circleci/bundler-cache/****/2.7.0/gems/net-protocol-0.2.1/lib/net/protocol.rb:214: warning: already initialized constant Net::BufferedIO::BUFSIZE
/usr/local/lib/****/2.7.0/net/protocol.rb:206: warning: previous definition of BUFSIZE was here
/home/circleci/bundler-cache/****/2.7.0/gems/net-protocol-0.2.1/lib/net/protocol.rb:541: warning: already initialized constant Net::NetPrivate::Socket
/usr/local/lib/****/2.7.0/net/protocol.rb:503: warning: previous definition of Socket was here
WARNING: Skipping foo.bar_id: it has multiple associations referencing different keys/tables.
WARNING: Skipping foo.bar_id: it has multiple associations referencing different keys/tables.
WARNING: Skipping foo.bar_id: it has multiple associations referencing different keys/tables.
WARNING: Skipping foo.bar_id: it has multiple associations referencing different keys/tables.
WARNING: Skipping foo.bar_id: it has multiple associations referencing different keys/tables.
Missing foreign key relationship on 'new_table.new_column_id' to 'other_table.id'
Found missing foreign keys, run `rails generate immigration MigrationName` to create a migration to add them.
```

There is a lot of noise (that's not this gem's fault) and then the useful message right at the bottom. A lot of that noise is repeated across many CI tasks and it's on us to fix it. But anyway...

I've seen two cases recently where someone has glossed over the really useful message at the bottom because of all the noise above it. So I'm proposing to add some line breaks to make the actionable bit stand out.