### PR TITLE
Support disallowing permanent connection checkouts with Rails 7.2

### DIFF
--- a/lib/immigrant/key_validator.rb
+++ b/lib/immigrant/key_validator.rb
@@ -26,7 +26,11 @@ module Immigrant
     end
 
     def connection
-      @connection ||= ActiveRecord::Base.connection
+      @connection ||= if ActiveRecord::Base.respond_to?(:lease_connection)
+        ActiveRecord::Base.lease_connection
+      else
+        ActiveRecord::Base.connection
+      end
     end
   end
 end


### PR DESCRIPTION
Context: https://github.com/rails/rails/pull/51349

Ensures that applications using `config.active_record.permanent_connection_checkout = :disallowed` are supported from Rails 7.2 onwards.